### PR TITLE
Fix locally defined scale variables

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigmacomputing/stitches-core",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The modern CSS-in-JS library",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/core/src/convert/toCssRules.js
+++ b/packages/core/src/convert/toCssRules.js
@@ -109,7 +109,14 @@ export const toCssRules = (
 						if (currentRule === undefined) currentRule = [[], selectors, conditions]
 
 						/** CSS left-hand side value, which may be a specially-formatted custom property. */
-						name = !isAtRuleLike && name.charCodeAt(0) === 36 ? `--${toTailDashed(config.prefix)}${NAMESPACE}${name.slice(1).replace(/\$/g, '-')}` : name
+						if (!isAtRuleLike && name.charCodeAt(0) === 36) {
+							const isLocalToken = name.charCodeAt(1) === 36;
+							name = '--'.concat(
+								toTailDashed(config.prefix),
+								isLocalToken ? NAMESPACE : '',
+								name.slice(1).replace(/\$/g, '-')
+							);
+						}
 
 						/** CSS right-hand side value, which may be a specially-formatted custom property. */
 						data = (

--- a/packages/core/tests/basic.js
+++ b/packages/core/tests/basic.js
@@ -228,6 +228,23 @@ describe('Basic', () => {
 		expect(cssString1of1).toBe(`--sxs{--sxs:2 fusion-c-elRGCe}@media{.fusion-c-elRGCe{--fusion-sxs-brand:500px;width:var(--fusion-sxs-brand)}}`)
 	})
 
+	test('Functionality of stringification — Local custom scales', () => {
+		const { css, getCssText } = createStitches({
+			prefix: 'fusion',
+		})
+
+		const component1of1 = css({
+			$common$offset: '500px',
+			width: '$common$offset',
+		})
+
+		const className1of1 = `${component1of1()}`
+		const cssString1of1 = getCssText()
+
+		expect(className1of1).toBe('fusion-c-beUcvW')
+		expect(cssString1of1).toBe(`--sxs{--sxs:2 fusion-c-beUcvW}@media{.fusion-c-beUcvW{--fusion-common-offset:500px;width:var(--fusion-common-offset)}}`)
+	})
+
 	test('Stringification: Utils + Local Tokens', () => {
 		const { css, getCssText } = createStitches({
 			utils: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigmacomputing/stitches-react",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The modern CSS-in-JS library",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/stringify/package.json
+++ b/packages/stringify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigmacomputing/stitches-stringify",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Converts an object into CSS",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigmacomputing/stitches-test",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "files": [
     "dist/*.cjs",


### PR DESCRIPTION
Fixes an issue where scale variables defined locally would not resolve to the proper css variable

Before:
`$colors$subtle: gray` >> `--sxscolors-subtle: gray` // broken
`$$commonOffset: 400px` >> `--sxs-common-offset: 400px` // ok

After:
`$colors$subtle: gray` >> `--colors-subtle: gray` // fixed
`$$commonOffset: 400px` >> `--sxs-common-offset: 400px` // still ok

This was broken in #14